### PR TITLE
skip track selection when no tracks available

### DIFF
--- a/src/Editor.c
+++ b/src/Editor.c
@@ -1621,7 +1621,13 @@ static void onTrackSide(enum ArrowDirection dir, bool startOrEnd, enum Selection
 	TrackData* trackData = getTrackData();
 	const int trackCount = getTrackCount();
 	const int oldTrack = getActiveTrack();
+	Track* oldT = &trackData->tracks[oldTrack];
 	int track = 0;
+
+	if (!oldT->group) {
+		// no tracks yet, doesn't make sense to act on them
+		return;
+	}
 
 	if (dir == ARROW_LEFT)
 		track = startOrEnd ? 0 : getPrevTrack();


### PR DESCRIPTION
Ignore arrow left/right actions if the "active track" has no group set,
which means that it's not a track. This fixes a crash that would happen
when attempting to access the current track's group, when the active
track is invalid (after starting the editor when nothing is connected,
or when the connection has no tracks).