### PR TITLE
added locale-neutral string<->float conversions

### DIFF
--- a/src/Editor.c
+++ b/src/Editor.c
@@ -402,7 +402,7 @@ static int drawCurrentValue(int posX, int sizeY)
 		value = (float)sync_get_val(track, current_row);
 	}
 
-	snprintf(valueText, 256, "%f", value);
+	my_ftoa(value, valueText, 256, 6);
 	Emgui_drawText(valueText, posX + 4, sizeY - 15, Emgui_color32(160, 160, 160, 255));
 	Emgui_drawBorder(Emgui_color32(10, 10, 10, 255), Emgui_color32(10, 10, 10, 255), posX, sizeY - 17, 80, 15);
 	Emgui_drawText(str, posX + 85, sizeY - 15, Emgui_color32(160, 160, 160, 255));
@@ -789,7 +789,7 @@ static void endEditing()
 	{
 
 		key.row = row_pos;
-		key.value = (float)atof(s_editBuffer);
+		key.value = (float)my_atof(s_editBuffer);
 		key.type = 0;
 
 		if (track->num_keys > 0)

--- a/src/TrackData.c
+++ b/src/TrackData.c
@@ -3,6 +3,8 @@
 #include "rlog.h"
 #include <stdio.h>
 #include <assert.h>
+#include <stdint.h>
+#include <ctype.h>
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -381,4 +383,56 @@ int TrackData_getNextLoopmark(TrackData* trackData, int row)
 int TrackData_getPrevLoopmark(TrackData* trackData, int row)
 {
 	return getPrevMark(trackData->loopmarks, trackData->loopmarkCount, row, -1);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// (simplified) locale-independent atof() implementation
+double my_atof(const char* s)
+{
+	int64_t value = 0, radix = 0;
+	char first;
+	if (!s || !s[0])
+	{
+		return 0.0;
+	}
+	first = s[0];
+	if (first == '-')
+	{
+		++s;
+	}
+	while (*s)
+	{
+		if (isdigit(*s))
+		{
+			value = (value * 10) + (*s - '0');
+			radix *= 10;
+		}
+		else if ((*s == '.') || (*s == ','))
+		{
+			radix = 1;
+		}
+		else
+		{
+			break;
+		}
+		++s;
+	}
+	radix = radix ? radix : 1;
+	radix = (first == '-') ? -radix : radix;
+	return (double)value / (double)radix;
+}
+
+void my_ftoa(float f, char* s, int n, int digits)
+{
+	char fmt[5] = "%.0f";
+	fmt[2] = digits + '0';
+	snprintf(s, n, fmt, f);
+	for (;  *s;  ++s)
+	{
+		if (*s == ',')
+		{
+			*s = '.';
+		}
+	}
 }

--- a/src/TrackData.h
+++ b/src/TrackData.h
@@ -121,3 +121,9 @@ uint32_t TrackData_getNextColor(TrackData* trackData);
 void TrackData_linkGroups(TrackData* trackData);
 void TrackData_linkTrack(int index, const char* name, TrackData* trackData);
 void TrackData_setActiveTrack(TrackData* trackData, int track);
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// utility functions
+double my_atof(const char* s);
+void my_ftoa(float f, char* s, int n, int digits);

--- a/src/TrackView.c
+++ b/src/TrackView.c
@@ -292,7 +292,7 @@ static void renderText(const struct TrackInfo* info, struct sync_track* track, i
 		{
 			char temp[256];
 			float value = track->keys[idx].value;
-			snprintf(temp, 256, "% .2f", value);
+			my_ftoa(value, temp, 256, 2);
 
 			Emgui_drawText(temp, x, y - font_size_half, Emgui_color32(255, 255, 255, 255));
 		}

--- a/src/loadsave.c
+++ b/src/loadsave.c
@@ -157,7 +157,7 @@ static void parseXml(mxml_node_t* rootNode, TrackData* trackData)
 					}
 
 					if (mute_value_text)
-						muteValue = (float)atof(mute_value_text);
+						muteValue = (float)my_atof(mute_value_text);
 
 					// If we already have this track loaded we delete all the existing keys
 
@@ -195,7 +195,7 @@ static void parseXml(mxml_node_t* rootNode, TrackData* trackData)
 					const char* interpolation = mxmlElementGetAttr(node, "interpolation");
 
 					k.row = atoi(row);
-					k.value = (float)(atof(value));
+					k.value = (float)(my_atof(value));
 					k.type = (atoi(interpolation));
 
 					// if track is muted we load the data into the muted data and not the regular keys
@@ -349,8 +349,7 @@ static void setElementInt(mxml_node_t* node, const char* attr, const char* forma
 static void setElementFloat(mxml_node_t* node, char* attr, float v)
 {
 	char temp[256];
-	memset(temp, 0, sizeof(temp));
-	sprintf(temp, "%f", v);
+	my_ftoa(v, temp, 256, 6);
 	mxmlElementSetAttr(node, attr, temp);
 }
 


### PR DESCRIPTION
The C runtime's atof() and sprintf("%f") functions
may only accept and generate locale-specific values,
in particular those with comma (',') instead of
period ('.') as decimal separator. This caused
several portability problems on systems that actually
make use of localized formats (e.g. GNU/Linux):
XML files weren't interchangeable with other systems,
and it wasn't even possible to enter fractional values.

This commit implements language-neutral (but somewhat
limited) my_atof() and my_ftoa() functions that
specifically take care of the comma-vs-period issue.