### PR TITLE
Handle SET_ROW and PAUSE coming from the demo side

### DIFF
--- a/src/Editor.c
+++ b/src/Editor.c
@@ -2076,6 +2076,15 @@ static int processCommands()
 
 				break;
 			}
+
+			case PAUSE:
+			{
+				onPlay();
+
+				ret = 1;
+
+				break;
+			}
 		}
 	}
 

--- a/src/Editor.c
+++ b/src/Editor.c
@@ -2036,7 +2036,6 @@ static int processCommands()
 
 			case SET_ROW:
 			{
-				//int i = 0;
 				ret = RemoteConnection_recv((char*)&newRow, sizeof(int), 0);
 
 				if (ret)
@@ -2044,6 +2043,33 @@ static int processCommands()
 					viewInfo->rowPos = htonl(newRow);
 					viewInfo->selectStartRow = viewInfo->selectStopRow = viewInfo->rowPos;
 					//rlog(R_INFO, "row from demo %d\n", s_editorData.trackViewInfo.rowPos);
+				}
+
+				ret = 1;
+
+				break;
+			}
+
+			case SET_KEY:
+			{
+				unsigned char type;
+				uint32_t track;
+				union {
+					float f;
+					uint32_t i;
+				} v;
+
+				if (RemoteConnection_recv((char*)&track, sizeof(track), 0) &&
+				    RemoteConnection_recv((char*)&newRow, sizeof(newRow), 0) &&
+				    RemoteConnection_recv((char*)&v.i, sizeof(v.i), 0) &&
+				    RemoteConnection_recv((char*)&type, sizeof(type), 0)) {
+
+					v.i = ntohl(v.i);
+					newRow = htonl(newRow);
+
+					viewInfo->selectStartRow = viewInfo->selectStopRow = viewInfo->rowPos = newRow;
+
+					doEdit(track, newRow, v.f);
 				}
 
 				ret = 1;

--- a/src/Editor.c
+++ b/src/Editor.c
@@ -865,80 +865,6 @@ void Editor_scroll(float deltaX, float deltaY, int flags)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-static int processCommands()
-{
-	int strLen, newRow, serverIndex;
-	unsigned char cmd = 0;
-	int ret = 0;
-	TrackViewInfo* viewInfo = getTrackViewInfo();
-
-	if (RemoteConnection_recv((char*)&cmd, 1, 0))
-	{
-		switch (cmd)
-		{
-			case GET_TRACK:
-			{
-				char trackName[4096];
-
-				reset_tracks = true;
-
-				memset(trackName, 0, sizeof(trackName));
-
-				RemoteConnection_recv((char *)&strLen, sizeof(int), 0);
-				strLen = ntohl(strLen);
-
-				if (!RemoteConnection_connected())
-					return 0;
-
-				if (!RemoteConnection_recv(trackName, strLen, 0))
-					return 0;
-
-				//rlog(R_INFO, "Got trackname %s (%d) from demo\n", trackName, strLen);
-
-				// find track
-
-				serverIndex = TrackData_createGetTrack(&s_editorData.trackData, trackName);
-				// if it's the first one we get, select it too
-				if (serverIndex == 0)
-					setActiveTrack(0);
-
-				// setup remap and send the keyframes to the demo
-				RemoteConnection_mapTrackName(trackName);
-				RemoteConnection_sendKeyFrames(trackName, s_editorData.trackData.syncTracks[serverIndex]);
-				TrackData_linkTrack(serverIndex, trackName, &s_editorData.trackData);
-
-				s_editorData.trackData.tracks[serverIndex].active = true;
-
-				ret = 1;
-
-				break;
-			}
-
-			case SET_ROW:
-			{
-				//int i = 0;
-				ret = RemoteConnection_recv((char*)&newRow, sizeof(int), 0);
-
-				if (ret)
-				{
-					viewInfo->rowPos = htonl(newRow);
-					viewInfo->selectStartRow = viewInfo->selectStopRow = viewInfo->rowPos;
-					//rlog(R_INFO, "row from demo %d\n", s_editorData.trackViewInfo.rowPos);
-				}
-
-				ret = 1;
-
-				break;
-			}
-		}
-	}
-
-	return ret;
-}
-
-
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 static void updateTrackStatus()
 {
 	int i, track_count = getTrackCount();
@@ -954,25 +880,6 @@ static void updateTrackStatus()
 		Editor_update();
 
 		reset_tracks = false;
-	}
-}
-
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-void Editor_timedUpdate()
-{
-	int processed_commands = s_editorData.trackData.musicData.percentDone != 0;
-
-	RemoteConnection_updateListner(getRowPos());
-
-	updateTrackStatus();
-
-	while (RemoteConnection_pollRead())
-		processed_commands |= processCommands();
-
-	if (!RemoteConnection_isPaused() || processed_commands)
-	{
-		Editor_update();
 	}
 }
 
@@ -2075,4 +1982,96 @@ bool Editor_keyDown(int key, int keyCode, int modifiers)
 	}
 
 	return true;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+static int processCommands()
+{
+	int strLen, newRow, serverIndex;
+	unsigned char cmd = 0;
+	int ret = 0;
+	TrackViewInfo* viewInfo = getTrackViewInfo();
+
+	if (RemoteConnection_recv((char*)&cmd, 1, 0))
+	{
+		switch (cmd)
+		{
+			case GET_TRACK:
+			{
+				char trackName[4096];
+
+				reset_tracks = true;
+
+				memset(trackName, 0, sizeof(trackName));
+
+				RemoteConnection_recv((char *)&strLen, sizeof(int), 0);
+				strLen = ntohl(strLen);
+
+				if (!RemoteConnection_connected())
+					return 0;
+
+				if (!RemoteConnection_recv(trackName, strLen, 0))
+					return 0;
+
+				//rlog(R_INFO, "Got trackname %s (%d) from demo\n", trackName, strLen);
+
+				// find track
+
+				serverIndex = TrackData_createGetTrack(&s_editorData.trackData, trackName);
+				// if it's the first one we get, select it too
+				if (serverIndex == 0)
+					setActiveTrack(0);
+
+				// setup remap and send the keyframes to the demo
+				RemoteConnection_mapTrackName(trackName);
+				RemoteConnection_sendKeyFrames(trackName, s_editorData.trackData.syncTracks[serverIndex]);
+				TrackData_linkTrack(serverIndex, trackName, &s_editorData.trackData);
+
+				s_editorData.trackData.tracks[serverIndex].active = true;
+
+				ret = 1;
+
+				break;
+			}
+
+			case SET_ROW:
+			{
+				//int i = 0;
+				ret = RemoteConnection_recv((char*)&newRow, sizeof(int), 0);
+
+				if (ret)
+				{
+					viewInfo->rowPos = htonl(newRow);
+					viewInfo->selectStartRow = viewInfo->selectStopRow = viewInfo->rowPos;
+					//rlog(R_INFO, "row from demo %d\n", s_editorData.trackViewInfo.rowPos);
+				}
+
+				ret = 1;
+
+				break;
+			}
+		}
+	}
+
+	return ret;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void Editor_timedUpdate()
+{
+	int processed_commands = s_editorData.trackData.musicData.percentDone != 0;
+
+	RemoteConnection_updateListner(getRowPos());
+
+	updateTrackStatus();
+
+	while (RemoteConnection_pollRead())
+		processed_commands |= processCommands();
+
+	if (!RemoteConnection_isPaused() || processed_commands)
+	{
+		Editor_update();
+	}
 }


### PR DESCRIPTION
These commits enable glrocket to work with the changes I've posted in an upstream GNU Rocket PR here https://github.com/rocket/rocket/pull/76

When used together, one may trivially turn a demo being created into a first-class participant of the pattern editing/creative process.

I've been experimenting with some minimal effort, just connecting space bar to sync_pause(), the mouse wheel to manipulating the row position, and mouse motion to manipulate camera position and orientation with clicks to commit the changes via sync_set_value() on the appropriate tracks, persisting the values in the editor as if I had manually typed them in.

It's already a huge improvement in the creative process.  Nobody wants to place and orient cameras by typing numbers in a pattern editor.  And this is just what I've done in a relatively short amount of time hacking on the demo side.

PTAL, thanks!

Note: You'll want to look at the individual commits, the first commit simply moves processCommands() and Editor_TimedUpdate() which pollutes the changeset when viewed as a whole.  There isn't really much going on here.