### PR TITLE
editor: denormalize track in SET_KEY case

### DIFF
--- a/src/Editor.c
+++ b/src/Editor.c
@@ -2066,6 +2066,7 @@ static int processCommands()
 
 					v.i = ntohl(v.i);
 					newRow = htonl(newRow);
+					track = htonl(track);
 
 					viewInfo->selectStartRow = viewInfo->selectStopRow = viewInfo->rowPos = newRow;
 


### PR DESCRIPTION
Missed the track in both my librocket and glrocket changes first
time around, so it worked in testing despite the oversight, oops!