### PR TITLE
linux: SDL_GL_DOUBLEBUFFER is not a valid CreateWindow flag

### DIFF
--- a/src/linux/main.c
+++ b/src/linux/main.c
@@ -423,7 +423,7 @@ int main(int argc, char* argv[]) {
 
     // SDL_EnableKeyRepeat(200, 20);
     window = SDL_CreateWindow("Rocket", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 800, 600,
-                              SDL_WINDOW_OPENGL | SDL_GL_DOUBLEBUFFER | SDL_WINDOW_RESIZABLE);
+                              SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
 
     if (!window) {
         fprintf(stderr, "SDL_CreateWindow(): %s\n", SDL_GetError());


### PR DESCRIPTION
Passing this as a flag is triggering an unexpected modeswitch, probably because the value maps to the fullscreen flag.