### PR TITLE
macOS: opt out of HiDPI OpenGL surface

### DIFF
--- a/src/macosx/RocketView.m
+++ b/src/macosx/RocketView.m
@@ -52,6 +52,8 @@ void Window_setTitle(const char* title);
 	if (self == nil)
 		return nil;
 
+	[self setWantsBestResolutionOpenGLSurface:NO];
+
 	NSOpenGLPixelFormatAttribute attributes[] = {
 			NSOpenGLPFADoubleBuffer,
 			0


### PR DESCRIPTION
Hi,

I've been wanting to use this on my MacBook for quite a while now, but I've had issues with scaling making it very hard to work with. I've seen there's plans for a Metal backend, but I wanted to see if I could find some quick-fix in the meantime, and I did. 😃 

It's a simple one-liner with the following result:

**Before**
<img width="912" alt="before" src="https://github.com/emoon/rocket/assets/4023218/00799918-2cbc-4522-a2fb-a144923ccba7">

**After**
<img width="912" alt="after" src="https://github.com/emoon/rocket/assets/4023218/81185629-7c3b-4d4c-b276-ccaf3b065f3e">

When looking at [the documentation](https://developer.apple.com/documentation/appkit/nsview/1414938-wantsbestresolutionopenglsurface#discussion) I saw that:

>For applications linked on macOS 10.15 or later, the default value of this property is true. For applications linked on macOS 10.14 or earlier, the default value of this property is false to keep binary compatibility.

Which likely explains why this worked fine before Catalina.

Thanks!