### PR TITLE
Leave the current row unmodified on SET_KEY.

### DIFF
--- a/src/Editor.c
+++ b/src/Editor.c
@@ -2148,8 +2148,6 @@ static int processCommands(RemoteConnection *conn) {
                     newRow = htonl(newRow);
                     track = htonl(track);
 
-                    viewInfo->selectStartRow = viewInfo->selectStopRow = viewInfo->rowPos = newRow;
-
                     doEditRaw(track, newRow, v.f, type);
                 }
 


### PR DESCRIPTION
Do not set the current row position to the inserted keyframe position
 when processing a SET_KEY command.